### PR TITLE
add serialization helper for blockchain-specs flag

### DIFF
--- a/avalanche-network-runner-sdk/Cargo.toml
+++ b/avalanche-network-runner-sdk/Cargo.toml
@@ -13,10 +13,10 @@ repository = "https://github.com/ava-labs/avalanche-network-runner-sdk-rs"
 log = "0.4.17"
 prost = "0.11.0"
 prost-types = "0.11.1"
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
-tokio = { version = "1.21.0", features = ["fs", "rt-multi-thread"] }
-tokio-stream = { version = "0.1.9", features = ["net"] }
+tokio = { version = "1.21.1", features = ["fs", "rt-multi-thread"] }
+tokio-stream = { version = "0.1.10", features = ["net"] }
 tonic = "0.8.1"
 
 [build-dependencies]
@@ -25,7 +25,7 @@ tonic-build = "0.8.0"
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"
-env_logger = "0.9.0"
+env_logger = "0.9.1"
 
 # serde_json is used in examples but fails cargo-udeps
 [package.metadata.cargo-udeps.ignore]

--- a/avalanche-network-runner-sdk/src/lib.rs
+++ b/avalanche-network-runner-sdk/src/lib.rs
@@ -34,6 +34,21 @@ pub struct GlobalConfig {
     pub log_level: String,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct BlockchainSpecs {
+    #[serde(rename = "vm_name")]
+    /// Name of the Vm.
+    pub vm_name: String,
+
+    /// Path to genesis file.
+    pub genesis: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "subnet_id")]
+    /// Id for the subnet.
+    pub subnet_id: Option<String>,
+}
+
 impl Client<Channel> {
     /// Creates a new network-runner client.
     ///
@@ -148,4 +163,39 @@ fn global_config() {
 
     let actual = serde_json::to_value(conf).unwrap();
     assert_json_include!(actual: actual, expected: expected)
+}
+
+#[test]
+fn block_chain_spec() {
+    use assert_json_diff::assert_json_include;
+    use serde_json::json;
+
+    let spec = BlockchainSpecs {
+        vm_name: "minikvvm".to_string(),
+        genesis: "/tmp/genesis.json".to_string(),
+        subnet_id: None,
+    };
+
+    let expected = json!({
+        "vm_name": "minikvvm",
+        "genesis": "/tmp/genesis.json"
+    });
+
+    let actual = serde_json::to_value(spec).unwrap();
+    assert_json_include!(actual: actual, expected: expected);
+
+    let spec = BlockchainSpecs {
+        vm_name: "minikvvm".to_string(),
+        genesis: "/tmp/genesis.json".to_string(),
+        subnet_id: Some("qBnAKUQ2mxiB1JdqsPPU7Ufuj1XmPLpnPTRvZEpkYZBmK6UjE".to_string()),
+    };
+
+    let expected = json!({
+        "vm_name": "minikvvm",
+        "genesis": "/tmp/genesis.json",
+        "subnet_id": "qBnAKUQ2mxiB1JdqsPPU7Ufuj1XmPLpnPTRvZEpkYZBmK6UjE",
+    });
+
+    let actual = serde_json::to_value(spec).unwrap();
+    assert_json_include!(actual: actual, expected: expected);
 }


### PR DESCRIPTION
This PR adds BlockchainSpecs stuct which assists with generating JSON for passing to the blockchain-specs key of `StartRequest`

```rust
 let blockchain_spec = BlockchainSpecs {
        vm_name: "minikvvm".to_string(),
        genesis: "/tmp/genesis.json".to_string(),
        subnet_id: Some("qBnAKUQ2mxiB1JdqsPPU7Ufuj1XmPLpnPTRvZEpkYZBmK6UjE".to_string()),
    };

 let resp = cli
        .start(StartRequest {
            exec_path: exec_path,
            whitelisted_subnets: Some(whitelisted_subnets),
            global_node_config: Some(serde_json::to_string(&global_config).unwrap()),
            plugin_dir: Some(plugin_dir),
            blockchain_specs: Some(serde_json::to_string(&blockchain_spec).unwrap()),
[..]
```