### PR TITLE
fix: Downgrade rust to 1.70

### DIFF
--- a/avalanche-network-runner-sdk/Cargo.toml
+++ b/avalanche-network-runner-sdk/Cargo.toml
@@ -2,7 +2,7 @@
 name = "avalanche-network-runner-sdk"
 version = "0.3.2" # https://crates.io/crates/avalanche-network-runner-sdk
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.70"
 publish = true
 description = "avalanche-network-runner-sdk in Rust"
 license = "BSD-3-Clause"

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e2e"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.70"
 publish = false
 description = "Avalanche network-runner SDK E2E tests"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Issues running v1.71 on M1 macs. We can downgrade for now.

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
