### PR TITLE
*: Bump to v0.3.3

### DIFF
--- a/avalanche-network-runner-sdk/Cargo.toml
+++ b/avalanche-network-runner-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanche-network-runner-sdk"
-version = "0.3.2" # https://crates.io/crates/avalanche-network-runner-sdk
+version = "0.3.3" # https://crates.io/crates/avalanche-network-runner-sdk
 edition = "2021"
 rust-version = "1.70"
 publish = true


### PR DESCRIPTION
This release downgrades to Rust 1.70 for the time being due to some toolchain issues on M1 macs. 

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
