### PR TITLE
Add support for missing RPC calls

### DIFF
--- a/avalanche-network-runner-sdk/rpcpb/rpc.proto
+++ b/avalanche-network-runner-sdk/rpcpb/rpc.proto
@@ -32,7 +32,10 @@ service ControlService {
   rpc AddPermissionlessValidator(AddPermissionlessValidatorRequest) returns (AddPermissionlessValidatorResponse) {
   }
 
-  rpc RemoveSubnetValidator(RemoveSubnetValidatorRequest) returns (RemoveSubnetValidatorResponse) {
+  rpc AddSubnetValidators(AddSubnetValidatorsRequest) returns (AddSubnetValidatorsResponse) {
+  }
+
+  rpc RemoveSubnetValidator(RemoveSubnetValidatorsRequest) returns (RemoveSubnetValidatorsResponse) {
   }
 
   rpc CreateSubnets(CreateSubnetsRequest) returns (CreateSubnetsResponse) {
@@ -59,8 +62,7 @@ service ControlService {
   rpc AddNode(AddNodeRequest) returns (AddNodeResponse) {
   }
 
-  rpc AddSubnetValidators(AddSubnetValidatorsRequest) returns (AddSubnetValidatorsResponse) {
-  }
+  
 
   rpc RestartNode(RestartNodeRequest) returns (RestartNodeResponse) {
   }
@@ -315,16 +317,16 @@ message AddPermissionlessDelegatorResponse {
   ClusterInfo cluster_info = 1;
 }
 
-message RemoveSubnetValidatorSpec {
+message RemoveSubnetValidatorsSpec {
   string subnet_id = 1;
   repeated string node_names = 2;
 }
 
-message RemoveSubnetValidatorRequest {
-  repeated RemoveSubnetValidatorSpec validator_spec = 1;
+message RemoveSubnetValidatorsRequest {
+  repeated RemoveSubnetValidatorsSpec validator_spec = 1;
 }
 
-message RemoveSubnetValidatorResponse {
+message RemoveSubnetValidatorsResponse {
   ClusterInfo cluster_info = 1;
 }
 

--- a/avalanche-network-runner-sdk/rpcpb/rpc.proto
+++ b/avalanche-network-runner-sdk/rpcpb/rpc.proto
@@ -59,6 +59,9 @@ service ControlService {
   rpc AddNode(AddNodeRequest) returns (AddNodeResponse) {
   }
 
+  rpc AddSubnetValidators(AddSubnetValidatorsRequest) returns (AddSubnetValidatorsResponse) {
+  }
+
   rpc RestartNode(RestartNodeRequest) returns (RestartNodeResponse) {
   }
 
@@ -281,6 +284,19 @@ message PermissionlessStakerSpec {
   string asset_id = 4;
   string start_time = 5;
   uint64 stake_duration = 6;
+}
+
+message SubnetValidatorsSpec {
+  string subnet_id = 1;
+  repeated string node_names = 2;
+}
+
+message AddSubnetValidatorsRequest {
+  repeated SubnetValidatorsSpec validator_spec = 1;
+}
+
+message AddSubnetValidatorsResponse {
+  ClusterInfo cluster_info = 1;
 }
 
 message AddPermissionlessValidatorRequest {

--- a/avalanche-network-runner-sdk/src/lib.rs
+++ b/avalanche-network-runner-sdk/src/lib.rs
@@ -20,7 +20,7 @@ pub use rpcpb::{
     AddNodeRequest, AddNodeResponse, BlockchainSpec, HealthRequest, HealthResponse, PingRequest,
     PingResponse, RemoveNodeRequest, RemoveNodeResponse, StartRequest, StartResponse,
     StatusRequest, StatusResponse, StopRequest, StopResponse, UrIsRequest, VmidRequest,
-    VmidResponse,
+    VmidResponse, ListBlockchainsRequest, ListBlockchainsResponse, ListSubnetsRequest, ListSubnetsResponse,
 };
 
 pub struct Client<T> {
@@ -211,6 +211,28 @@ impl Client<Channel> {
             .vmid(req)
             .await
             .map_err(|e| Error::new(ErrorKind::Other, format!("failed vm_id '{}'", e)))?;
+        let resp = resp.into_inner();
+        Ok(resp)
+    }
+
+    pub async fn list_blockchains(&self, req: ListBlockchainsRequest) -> io::Result<ListBlockchainsResponse> {
+        let mut control_client = self.grpc_client.control_client.lock().await;
+        let req = tonic::Request::new(req);
+        let resp = control_client
+            .list_blockchains(req)
+            .await
+            .map_err(|e| Error::new(ErrorKind::Other, format!("failed list_blockchains '{}'", e)))?;
+        let resp = resp.into_inner();
+        Ok(resp)
+    }
+
+    pub async fn list_subnets(&self, req: ListSubnetsRequest) -> io::Result<ListSubnetsResponse> {
+        let mut control_client = self.grpc_client.control_client.lock().await;
+        let req = tonic::Request::new(req);
+        let resp = control_client
+            .list_subnets(req)
+            .await
+            .map_err(|e| Error::new(ErrorKind::Other, format!("failed list_subnets '{}'", e)))?;
         let resp = resp.into_inner();
         Ok(resp)
     }

--- a/avalanche-network-runner-sdk/src/lib.rs
+++ b/avalanche-network-runner-sdk/src/lib.rs
@@ -19,7 +19,8 @@ pub use rpcpb::{
     control_service_client::ControlServiceClient, ping_service_client::PingServiceClient,
     AddNodeRequest, AddNodeResponse, BlockchainSpec, HealthRequest, HealthResponse, PingRequest,
     PingResponse, RemoveNodeRequest, RemoveNodeResponse, StartRequest, StartResponse,
-    StatusRequest, StatusResponse, StopRequest, StopResponse, UrIsRequest,
+    StatusRequest, StatusResponse, StopRequest, StopResponse, UrIsRequest, VmidRequest,
+    VmidResponse,
 };
 
 pub struct Client<T> {
@@ -199,6 +200,17 @@ impl Client<Channel> {
                     format!("failed remove_subnet_validator '{}'", e),
                 )
             })?;
+        let resp = resp.into_inner();
+        Ok(resp)
+    }
+
+    pub async fn vm_id(&self, req: VmidRequest) -> io::Result<VmidResponse> {
+        let mut control_client = self.grpc_client.control_client.lock().await;
+        let req = tonic::Request::new(req);
+        let resp = control_client
+            .vmid(req)
+            .await
+            .map_err(|e| Error::new(ErrorKind::Other, format!("failed vm_id '{}'", e)))?;
         let resp = resp.into_inner();
         Ok(resp)
     }

--- a/avalanche-network-runner-sdk/src/lib.rs
+++ b/avalanche-network-runner-sdk/src/lib.rs
@@ -13,8 +13,9 @@ pub mod rpcpb {
 }
 pub use rpcpb::{
     control_service_client::ControlServiceClient, ping_service_client::PingServiceClient,
-    BlockchainSpec, HealthRequest, HealthResponse, PingRequest, PingResponse, StartRequest,
-    StartResponse, StatusRequest, StatusResponse, StopRequest, StopResponse, UrIsRequest,
+    AddNodeRequest, AddNodeResponse, BlockchainSpec, HealthRequest, HealthResponse, PingRequest,
+    PingResponse, RemoveNodeRequest, RemoveNodeResponse, StartRequest, StartResponse,
+    StatusRequest, StatusResponse, StopRequest, StopResponse, UrIsRequest,
 };
 
 pub struct Client<T> {
@@ -131,6 +132,32 @@ impl Client<Channel> {
 
         let stop_resp = resp.into_inner();
         Ok(stop_resp)
+    }
+
+    /// Add a node to the currently running cluster.
+    pub async fn add_node(&self, req: AddNodeRequest) -> io::Result<AddNodeResponse> {
+        let mut control_client = self.grpc_client.control_client.lock().await;
+        let req = tonic::Request::new(req);
+        let resp = control_client
+            .add_node(req)
+            .await
+            .map_err(|e| Error::new(ErrorKind::Other, format!("failed add_node '{}'", e)))?;
+
+        let add_node_resp = resp.into_inner();
+        Ok(add_node_resp)
+    }
+
+    /// Remove a node from the currently running cluster.
+    pub async fn remove_node(&self, req: RemoveNodeRequest) -> io::Result<RemoveNodeResponse> {
+        let mut control_client = self.grpc_client.control_client.lock().await;
+        let req = tonic::Request::new(req);
+        let resp = control_client
+            .remove_node(req)
+            .await
+            .map_err(|e| Error::new(ErrorKind::Other, format!("failed remove_node '{}'", e)))?;
+
+        let remove_node_resp = resp.into_inner();
+        Ok(remove_node_resp)
     }
 }
 

--- a/avalanche-network-runner-sdk/src/lib.rs
+++ b/avalanche-network-runner-sdk/src/lib.rs
@@ -187,6 +187,7 @@ impl Client<Channel> {
         Ok(resp)
     }
 
+    /// Adds a new permissionless validator to the network.
     pub async fn add_validator(
         &self,
         req: AddSubnetValidatorsRequest,
@@ -201,6 +202,7 @@ impl Client<Channel> {
         Ok(resp)
     }
 
+    /// Removes a validator from the network.
     pub async fn remove_validator(
         &self,
         req: RemoveSubnetValidatorsRequest,
@@ -220,6 +222,7 @@ impl Client<Channel> {
         Ok(resp)
     }
 
+    /// Fetches the VM ID for the current cluster.
     pub async fn vm_id(&self, req: VmidRequest) -> io::Result<VmidResponse> {
         let mut control_client = self.grpc_client.control_client.lock().await;
         let req = tonic::Request::new(req);
@@ -231,6 +234,7 @@ impl Client<Channel> {
         Ok(resp)
     }
 
+    /// Fetches the list of blockchains for the current cluster.
     pub async fn list_blockchains(
         &self,
         req: ListBlockchainsRequest,
@@ -244,6 +248,7 @@ impl Client<Channel> {
         Ok(resp)
     }
 
+    /// Fetches the list of subnets for the current cluster.
     pub async fn list_subnets(&self, req: ListSubnetsRequest) -> io::Result<ListSubnetsResponse> {
         let mut control_client = self.grpc_client.control_client.lock().await;
         let req = tonic::Request::new(req);

--- a/avalanche-network-runner-sdk/src/lib.rs
+++ b/avalanche-network-runner-sdk/src/lib.rs
@@ -4,6 +4,10 @@ use std::{
 };
 
 use log::info;
+use rpcpb::{
+    AddPermissionlessValidatorRequest, AddPermissionlessValidatorResponse,
+    RemoveSubnetValidatorRequest, RemoveSubnetValidatorResponse,
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tonic::transport::Channel;
@@ -158,6 +162,45 @@ impl Client<Channel> {
 
         let remove_node_resp = resp.into_inner();
         Ok(remove_node_resp)
+    }
+
+    /// Adds a new validator to the network.
+    pub async fn add_validator(
+        &self,
+        req: AddPermissionlessValidatorRequest,
+    ) -> io::Result<AddPermissionlessValidatorResponse> {
+        let mut control_client = self.grpc_client.control_client.lock().await;
+        let req = tonic::Request::new(req);
+        let resp = control_client
+            .add_permissionless_validator(req)
+            .await
+            .map_err(|e| {
+                Error::new(
+                    ErrorKind::Other,
+                    format!("failed add_permissionless_validator '{}'", e),
+                )
+            })?;
+        let resp = resp.into_inner();
+        Ok(resp)
+    }
+
+    pub async fn remove_validator(
+        &self,
+        req: RemoveSubnetValidatorRequest,
+    ) -> io::Result<RemoveSubnetValidatorResponse> {
+        let mut control_client = self.grpc_client.control_client.lock().await;
+        let req = tonic::Request::new(req);
+        let resp = control_client
+            .remove_subnet_validator(req)
+            .await
+            .map_err(|e| {
+                Error::new(
+                    ErrorKind::Other,
+                    format!("failed remove_subnet_validator '{}'", e),
+                )
+            })?;
+        let resp = resp.into_inner();
+        Ok(resp)
     }
 }
 


### PR DESCRIPTION
We needed the rust ANR client to support additional `avalanchego` RPC calls. I've added them and these have been tested as part of our simulator testing tool. If you'd like to see that it's [here](https://github.com/movemntdev/M1/pull/108)

Open to any changes request. 